### PR TITLE
Minor grammatical changes

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ bodyClass: index
     <div class="wrap">
       <div id="web_of_datasets" class="feature_description">
         <h2>Qri is a Web of Datasets</h2>
-        <p>qri is built around datasets. Bigger than a spreadsheet, smaller than a database, datasets are all around us. qri is a big dataset bonanza, where people of all stripes can mix together all their sweet sweet data.</p>
+        <p>Qri is built around datasets. Bigger than a spreadsheet, smaller than a database, datasets are all around us. qri is a big dataset bonanza, where people of all stripes can mix together all their sweet sweet data.</p>
       </div>
       <div id="open_source" class="feature_description">
         <h2>This Party is Free and Open Source</h2>
@@ -76,7 +76,7 @@ bodyClass: index
         </div>
         <div id="git_style" class="feature_description">
           <h3>Git-style version control</h3>
-          <p>qri’s dataset versioning system is  inspired by git, and signs each commit with your identifying keypair. Because qri is only about datasets, qri generates commit messages for you.</p>
+          <p>Qri’s dataset versioning system is inspired by git, and signs each commit with your identifying keypair. Because qri is only about datasets, qri generates commit messages for you.</p>
         </div>
         <div id="data_formats" class="feature_description">
           <h3>Native support for JSON, CSV, CBOR data formats</h3>
@@ -84,11 +84,11 @@ bodyClass: index
         </div>
         <div id="meta_specs" class="feature_description">
           <h3>Metadata based on library science</h3>
-          <p>Librarians are better at metadata than developers, so we based our metadata spec on DCAT & Project Open Data,  for cleaner integration with existing data catlogs</p>
+          <p>Librarians are better at metadata than developers, so we based our metadata spec on DCAT & Project Open Data, for cleaner integration with existing data catlogs</p>
         </div>
         <div id="json_schemas" class="feature_description">
-          <h3>JSON-Schema’s for validation & OpenAPIs</h3>
-          <p>dataset schemas are defined with the same spec that drives OpenAPIs. Datasets automatically generate a JSON API & accompanying OpenAPI documentation</p>
+          <h3>JSON-Schemas for validation & OpenAPIs</h3>
+          <p>Dataset schemas are defined with the same spec that drives OpenAPIs. Datasets automatically generate a JSON API & accompanying OpenAPI documentation</p>
         </div>
         <div id="transformations" class="feature_description">
           <h3>Automate data munging with Python’s cousin: Skylark</h3>

--- a/docs/blog/datasets_are_books/index.html
+++ b/docs/blog/datasets_are_books/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/company/index.html
+++ b/docs/company/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/content-addressing/index.html
+++ b/docs/docs/concepts/content-addressing/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/index.html
+++ b/docs/docs/concepts/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/names/index.html
+++ b/docs/docs/concepts/names/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/overview/index.html
+++ b/docs/docs/concepts/overview/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/registries/index.html
+++ b/docs/docs/concepts/registries/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/set_value_cascade/index.html
+++ b/docs/docs/concepts/set_value_cascade/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/concepts/version_control/index.html
+++ b/docs/docs/concepts/version_control/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/reference/dataset/index.html
+++ b/docs/docs/reference/dataset/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/reference/glossary/index.html
+++ b/docs/docs/reference/glossary/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/reference/html_templates/index.html
+++ b/docs/docs/reference/html_templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/reference/index.html
+++ b/docs/docs/reference/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/reference/skylark_syntax/index.html
+++ b/docs/docs/reference/skylark_syntax/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/tutorials/cli_quickstart/index.html
+++ b/docs/docs/tutorials/cli_quickstart/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/tutorials/index.html
+++ b/docs/docs/tutorials/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/docs/tutorials/skylark_transformations/index.html
+++ b/docs/docs/tutorials/skylark_transformations/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -132,7 +132,7 @@
     <div class="wrap">
       <div id="web_of_datasets" class="feature_description">
         <h2>Qri is a Web of Datasets</h2>
-        <p>qri is built around datasets. Bigger than a spreadsheet, smaller than a database, datasets are all around us. qri is a big dataset bonanza, where people of all stripes can mix together all their sweet sweet data.</p>
+        <p>Qri is built around datasets. Bigger than a spreadsheet, smaller than a database, datasets are all around us. qri is a big dataset bonanza, where people of all stripes can mix together all their sweet sweet data.</p>
       </div>
       <div id="open_source" class="feature_description">
         <h2>This Party is Free and Open Source</h2>
@@ -187,7 +187,7 @@
         </div>
         <div id="git_style" class="feature_description">
           <h3>Git-style version control</h3>
-          <p>qri’s dataset versioning system is  inspired by git, and signs each commit with your identifying keypair. Because qri is only about datasets, qri generates commit messages for you.</p>
+          <p>Qri’s dataset versioning system is inspired by git, and signs each commit with your identifying keypair. Because qri is only about datasets, qri generates commit messages for you.</p>
         </div>
         <div id="data_formats" class="feature_description">
           <h3>Native support for JSON, CSV, CBOR data formats</h3>
@@ -195,11 +195,11 @@
         </div>
         <div id="meta_specs" class="feature_description">
           <h3>Metadata based on library science</h3>
-          <p>Librarians are better at metadata than developers, so we based our metadata spec on DCAT & Project Open Data,  for cleaner integration with existing data catlogs</p>
+          <p>Librarians are better at metadata than developers, so we based our metadata spec on DCAT & Project Open Data, for cleaner integration with existing data catlogs</p>
         </div>
         <div id="json_schemas" class="feature_description">
-          <h3>JSON-Schema’s for validation & OpenAPIs</h3>
-          <p>dataset schemas are defined with the same spec that drives OpenAPIs. Datasets automatically generate a JSON API & accompanying OpenAPI documentation</p>
+          <h3>JSON-Schemas for validation & OpenAPIs</h3>
+          <p>Dataset schemas are defined with the same spec that drives OpenAPIs. Datasets automatically generate a JSON API & accompanying OpenAPI documentation</p>
         </div>
         <div id="transformations" class="feature_description">
           <h3>Automate data munging with Python’s cousin: Skylark</h3>

--- a/docs/papers/index.html
+++ b/docs/papers/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-  <meta name="generator" content="Hugo 0.37-DEV" />
+  <meta name="generator" content="Hugo 0.44" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Capitalized some Qs wherever they began 'paragraphs' for consistency's sake. Also eliminated some duplicate spaces.