### PR TITLE
Bump up the z-index of docs menu on small screens

### DIFF
--- a/themes/qri_io/static/css/docs.css
+++ b/themes/qri_io/static/css/docs.css
@@ -57,6 +57,7 @@
 
 #docs_sidebar .content {
   position: fixed;
+  z-index: 9;
   overflow: auto;
   padding-bottom: 40px;
   width: 25%;


### PR DESCRIPTION
On some docs pages, we have absolutely positioned content. Because the navigation comes *before* the content, that means content shows up in front of the menu, like this:

![Screen Shot 2019-06-03 at 10 22 15 AM](https://user-images.githubusercontent.com/74178/58822329-173a8d00-85ec-11e9-803d-b47d9acb88fb.png)

I set an explicit z-index on the menu content that is just below the menu toggle. Ideally, I’d use CSS custom properties so there aren’t a bunch of magical z-index values floating around the CSS file, but I’m not sure what browsers you’re aiming to be compatible with.