### PR TITLE
fix(CNAME): fix ci-pusher wiping out qri.io domain name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
               git config --global user.name "Qri CI Deployer"
               git init
               git checkout -b gh-pages
+              echo "qri.io" > CNAME
               git add .
               git commit -m "deploy"
               git remote add origin git@github.com:qri-io/website.git


### PR DESCRIPTION
build script needs to write a file called CNAME to the publish directory.

More info: https://github.com/tschaub/gh-pages/issues/213#issuecomment-463283771