### PR TITLE
fix: update github edit url and fix one link

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,7 +45,7 @@ const config = {
     title: 'Qri.io',
     description: 'Qri Website and Documentation',
     ogImage: null,
-    docsLocation: 'https://github.com/qri-io/website-refresh/blob/master/content',
+    docsLocation: 'https://github.com/qri-io/website/blob/master/content',
     favicon: 'https://graphql-engine-cdn.hasura.io/img/hasura_icon_black.svg'
   },
   pwa: {

--- a/content/docs/getting-started/qri-desktop-quickstart.md
+++ b/content/docs/getting-started/qri-desktop-quickstart.md
@@ -67,6 +67,6 @@ That’s it!  Once the dataset is transferred, your dataset will have a shiny ne
 Here are some things to try now that you’re up and running:
 
 - Browse the full [Qri Desktop Manual](/docs/qri-desktop-manual/overview)
-- Find other users’ datasets on [Qri Cloud](https://qri.io/cloud)
+- Find other users’ datasets on [Qri Cloud](https://qri.cloud)
 - Try out the [Qri CLI](/docs/qri-cli-manual/overview)
 - Drop into [our discord server](https://discordapp.com/invite/thkJHKj) to chat about Qri


### PR DESCRIPTION
"Edit on Github" links were going to the now-archived `wesbite-refresh` repo.

This PR updates these links, and also fixes a bad link to qri.cloud.