### PR TITLE
fix: update footer link for CLI

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -13,7 +13,7 @@ const Footer = () => {
             <h5>Download</h5>
             <ul>
               <li><Link to='/download'>Qri Desktop</Link></li>
-              <li><Link to='/download'>Qri CLI</Link></li>
+              <li><ExternalLink to='https://github.com/qri-io/qri/releases'>Qri CLI</ExternalLink></li>
             </ul>
           </div>
           <div className='col-12 col-sm-4 col-md-2'>


### PR DESCRIPTION
Updates footer link for "Download Qri CLI" to point to the github releases page.