### PR TITLE
fix: add redirect for dataset spec

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,6 +24,7 @@ const redirects = [
   ['/docs/tutorials/cli-quickstart', '/docs/getting-started/qri-cli-quickstart'],
   ['/docs/tutorials/*', '/docs'],
   ['/docs/tutorials', '/docs'],
+  ['/docs/reference/dataset-specification/', '/docs/reference/dataset'],
   ['/docs/reference/starlark_syntax', '/docs/starlark/syntax'],
   ['/docs/reference/starlark_examples', '/docs/starlark/examples'],
   ['/docs/reference/starlib', '/docs/starlark/starlib'],


### PR DESCRIPTION
Adds a redirect for dead link: https://qri.io/docs/reference/dataset-specification/