### PR TITLE
feat(install.sh): add /install.sh redirect

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,9 @@ const redirects = [
   ['/docs/reference', '/docs'],
   ['/docs/workflows', '/docs'],
 
-  ['/papers/deterministic_querying', '/deterministic-querying']
+  ['/papers/deterministic_querying', '/deterministic-querying'],
+
+  ['/install.sh', 'https://raw.githubusercontent.com/qri-io/qri_install/master/install.sh']
 ]
 
 exports.createPages = ({ graphql, actions }) => {


### PR DESCRIPTION
This'll allow for a nice-looking one-liner install that also passes through a domain name we control over TLS: https://qri.io/install.sh

This sets the stage for installing the qri CLI with a one-liner. based directly on https://deno.land

If this works we can add the following instruction for installing qri CLI for linux & os x:
```
curl -fsSL https://qri.io/install.sh | sh
```