### PR TITLE
fix: document frontmatter fields for qri version info, update paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,13 @@ This is the repo for https://qri.io, our beloved website. Changes, fixes & pull 
 
 ## Overview
 
-This site is built with [gatsby](https://www.gatsbyjs.org/), a javascript static site generator, using the [gatsby-gitbook-starter](https://www.gatsbyjs.org/starters/hasura/gatsby-gitbook-starter/) site template.  The template has been modified to serve both a full-featured documentation site (markdown files in `/docs`) and standard pages (jsx files in `/pages`)
+This site is built with [gatsby](https://www.gatsbyjs.org/), a javascript static site generator, using the [gatsby-gitbook-starter](https://www.gatsbyjs.org/starters/hasura/gatsby-gitbook-starter/) site template.  The template has been modified to serve both a full-featured documentation site (markdown files in `/content/`) and standard pages (jsx files in `/src/pages/`)
 
 ## Development
 
 You should have `node` and `yarn` already installed on your machine.
 
-You'll also need `gatsby-cli`, which you can install with `npm install -g gatsby-cli`
+You’ll also need `gatsby-cli`, which you can install with `npm install -g gatsby-cli`
 
 To run the dev server:
 
@@ -26,7 +26,7 @@ Things such as the site title, navbar links, docs group ordering, etc are all co
 
 ## docs
 
-Documentation pages can be added by creating markdown files in the `/docs` directory.  Directories in `/docs` become groups, and each documentation article must belong to a group.
+Documentation pages can be added by creating markdown files in the `/content/docs/` directory.  Directories in `/content/docs/` become groups, and each documentation article must belong to a group.
 
 ### Ordering Groups
 
@@ -34,7 +34,7 @@ Group ordering is config-driven using `config.sidebar.forcedNavOrder`
 
 ### Ordering Documentation Articles
 
-Docs articles will list in alphabetical order by default, but can be ordered manually by specifying a `weight` (number) property in the markdown frontmatter.  Lower weight will be given higher priority
+Docs articles will list in alphabetical order by default, but can be ordered manually by specifying a `weight` (number) property in the markdown [frontmatter](https://www.gatsbyjs.org/docs/adding-markdown-pages/#frontmatter-for-metadata-in-markdown-files).  Lower weight will be given higher priority
 
 ## Redirects
 
@@ -43,15 +43,24 @@ Redirects are defined in `gatsby-node.js`.  The plugin `gatsby-plugin-netlify` g
 ## Markdown Docs vs Markdown Pages
 
 ### Docs
-For the `/docs` section of the site, all content lives in `/content/docs`, and can be markdown or MDX.  These are transformed into pages via `createPages()` in `gatsby-node.js`, which does all the fancy graphQL work to make the docs navigation (left sidebar) and contents (right sidebar).
+For the `/docs` section of the site, all content lives in `/content/docs/`, and can be markdown or MDX.  These are transformed into pages via `createPages()` in `gatsby-node.js`, which does all the fancy graphQL work to make the docs navigation (left sidebar) and contents (right sidebar).
 
 ### Pages
-Most of the content in `/pages` is JSX, but you can mix in markdown files as well.  These are simply rendered and placed into a simple layout component (`src/layouts/markdown-page.js`).  There is no complex graphQL stuff, but the following frontmatter fields should exist so we can populate the title and head meta on these pages:
+Most of the content in `/src/pages/` is JSX, but you can mix in markdown files as well.  These are simply rendered and placed into a simple layout component (`/src/layouts/markdown-page.js`). There is no complex graphQL stuff.
+
+## Frontmatter
+
+`metaTitle` and `metaDescription` populate the meta information for generated pages. `weight` controls [navigation order](#ordering-documentation-articles).
+
+If you are editing a page whose content can get stale with new versions of Qri, please update the `qriVersion` and `qriVersion` fields with the current version information.
 
 ```
 ---
 metaTitle: "Frequently Asked Questions"
 metaDescription: "Frequently Asked Questions about Qri"
+qriVersion: "0.9.9"
+qriDesktop: "0.4.2"
+weight: 4
 ---
 ```
 
@@ -66,7 +75,7 @@ There are a few one-off scripts that programmatically generate content. They liv
 
 ### Jobs
 
-To add a job listing, create a markdown file in `src/pages/jobs` with a filename that starts with `jobs-`.  This will be picked up by the graphql query in `src/pages/jobs/index` and will show up in the list.
+To add a job listing, create a markdown file in `/src/pages/jobs/` with a filename that starts with `jobs-`.  This will be picked up by the graphql query in `/src/pages/jobs/index` and will show up in the list.
 
 If no markdown files match the query, a message saying there are no current openings is shown instead.
 


### PR DESCRIPTION
document frontmatter fields for qri version info
update paths for docs and pages
use curly apostrophes

closes #224