### PR TITLE
fix: correct broken links for featured datasets

### DIFF
--- a/src/components/DatasetSummary.js
+++ b/src/components/DatasetSummary.js
@@ -24,7 +24,7 @@ const DatasetSummary = ({ dataset }) => {
   }
 
   return (
-    <ListItem key={path} link={`/${peername}/${name}`}>
+    <ListItem key={path} link={`https://qri.cloud/${peername}/${name}`}>
 
       <div className='row dataset-summary'>
         <div className='col-12 pb-1'>


### PR DESCRIPTION
change relative links to absolute to qri.cloud

closes #230