### PR TITLE
docs(qri-python): add docs for qri python client

### DIFF
--- a/content/docs/reference/qri_python_commands.md
+++ b/content/docs/reference/qri_python_commands.md
@@ -1,0 +1,49 @@
+---
+metaTitle: "Qri Python Commands"
+metaDescription: "An Overview of Qri Python Client Commands"
+weight: 9
+---
+
+# qri
+
+Client for interacting with qri repositories
+
+#### list
+
+```python
+list(username=None)
+```
+
+list datasets in the user's repository
+
+#### get
+
+```python
+get(refstr)
+```
+
+get a dataset in the repository by reference
+
+#### pull
+
+```python
+pull(refstr)
+```
+
+pull a remote dataset from the registry to the user's repository
+
+#### add
+
+```python
+add(refstr)
+```
+
+add is an alias for pull
+
+#### sql
+
+```python
+sql(query)
+```
+
+sql query run against a dataset


### PR DESCRIPTION
Adding in the auto-generated docs from the pydoc-markdown script we just included in the qri-python project. 

The intent here is that this page will be periodically updated by running the script in qri-python & copypasta-ing here.