### PR TITLE
fix: upgrade version number on desktop downloads page to latest v0.4.4

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -7,9 +7,13 @@ import { faFileExcel } from '@fortawesome/free-solid-svg-icons'
 import Head from '../components/Head'
 import ExternalLink from '../components/ExternalLink'
 
-const latestVersion = '0.4.4'
+const latestVersion = '0.4.5'
 const macDownloadUrl = `https://github.com/qri-io/desktop/releases/download/v${latestVersion}/Qri-Desktop-${latestVersion}.dmg`
-const windowsDownloadUrl = `https://github.com/qri-io/desktop/releases/download/v${latestVersion}/Qri.Desktop.Setup.${latestVersion}.exe`
+
+// TODO (ramfox): when we add the windows release to the desktop releases page, remove line 14 & 15 and
+// uncomment line 16
+const windowsDownloadUrl = 'https://github.com/qri-io/desktop/releases/download/v0.4.4/Qri.Desktop.Setup.0.4.4.exe'
+// const windowsDownloadUrl = `https://github.com/qri-io/desktop/releases/download/v${latestVersion}/Qri.Desktop.Setup.${latestVersion}.exe`
 
 // the first argument in track() becomes the google analytics 'Action' property after passing through segment
 const handleDownloadClick = (os) => {


### PR DESCRIPTION
this only changes the download link for the macos version, we will have to update when the windows release is added to the releases page.