### PR TITLE
Changed to --body parameter for qri init

### DIFF
--- a/content/docs/getting-started/qri-cli-quickstart.md
+++ b/content/docs/getting-started/qri-cli-quickstart.md
@@ -1,7 +1,7 @@
 ---
 metaTitle: "Qri CLI Quickstart"
 metaDescription: "Getting started with Qri’s Command Line Interface. Qri is a distributed dataset version control and sharing system"
-qriVersion: "0.9.11"
+qriVersion: "0.9.13"
 qriDesktop: "0.4.4"
 weight: 3
 ---
@@ -84,7 +84,7 @@ Navigate to your empty dataset directory and run `qri init` with the `--source-b
 
 ```bash
 $ cd ~/datasets/usgs_earthquakes
-$ qri init --source-body-path ~/downloads/earthquakes.csv
+$ qri init --body ~/downloads/earthquakes.csv
 Name of new dataset [usgs_earthquakes]: usgs_earthquakes
 
 initialized working directory for new dataset foo/usgs_earthquakes


### PR DESCRIPTION
With qri 0.9.13 I had problems initializing a dataset. I've figured out that there isn't a `--source-body-path` parameter anymore and I need to use `--body` instead.