### PR TITLE
Changed to --body parameter *in text* for qri init

### DIFF
--- a/content/docs/getting-started/qri-cli-quickstart.md
+++ b/content/docs/getting-started/qri-cli-quickstart.md
@@ -80,7 +80,7 @@ mkdir ~/datasets/usgs_earthquakes
 </InfoBlock>
 
 
-Navigate to your empty dataset directory and run `qri init` with the `--source-body-path` flag to import your CSV and create a new dataset.  Qri will ask you to name your dataset.  The dataset name may consist only of lowercase letters, numbers, and underscores/hyphens, and must be 100 characters or fewer. See [Naming Datasets](/docs/working-with-datasets/naming) for more on Qri naming conventions.
+Navigate to your empty dataset directory and run `qri init` with the `--body` flag to import your CSV and create a new dataset.  Qri will ask you to name your dataset.  The dataset name may consist only of lowercase letters, numbers, and underscores/hyphens, and must be 100 characters or fewer. See [Naming Datasets](/docs/working-with-datasets/naming) for more on Qri naming conventions.
 
 ```bash
 $ cd ~/datasets/usgs_earthquakes


### PR DESCRIPTION
Similar to fix https://github.com/qri-io/website/commit/dcc96c767a6873f0f029bf418014eeb441688e3c, but also updated the *in text* reference from `--source-body-path` to `--body`. Also using cli qri 0.9.13.