### PR TITLE
Clean up build warnings

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -130,8 +130,7 @@ module.exports = {
     tweetText: config.header.tweetText,
     mainHeaderLinks: config.header.mainLinks,
     docsHeaderLinks: config.header.docsLinks,
-    siteUrl: config.gatsby.siteUrl,
-    docsSections: config.docsSections
+    siteUrl: config.gatsby.siteUrl
   },
   plugins: plugins
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -59,16 +59,6 @@ exports.createPages = ({ graphql, actions }) => {
       graphql(
         `
           {
-            site {
-              siteMetadata {
-                docsSections {
-                  title
-                  path
-                  description
-                  colorClass
-                }
-              }
-            }
             allMdx(filter: {fileAbsolutePath: {regex: "\\/docs/"}}) {
               edges {
                 node {

--- a/src/components/DocsContent.js
+++ b/src/components/DocsContent.js
@@ -3,13 +3,12 @@ import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
 import { MDXProvider } from '@mdx-js/react'
 
 import mdxComponents from './mdxComponents'
-import RightSidebar from './RightSidebar'
 import DocsFooter from './DocsFooter'
 
 import Head from '../components/Head'
 
 const DocsContent = (props) => {
-  const { data, location } = props
+  const { data } = props
   if (!data) {
     return null
   }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -16,15 +16,6 @@ if (isSearchEnabled && config.header.search.indexName) {
   )
 }
 
-function myFunction () {
-  var x = document.getElementById('navbar')
-  if (x.className === 'topnav') {
-    x.className += ' responsive'
-  } else {
-    x.className = 'topnav'
-  }
-}
-
 export const useDisableBodyScroll = (open) => {
   useEffect(() => {
     if (open) {

--- a/src/components/search/SearchModal.js
+++ b/src/components/search/SearchModal.js
@@ -12,6 +12,8 @@ import CustomSearchBox from './CustomSearchBox'
 import CustomResults from './CustomResults'
 import Icon from '../Icon'
 
+import config from '../../../config'
+
 const algoliaClient = algoliasearch(
   process.env.GATSBY_ALGOLIA_APP_ID,
   process.env.GATSBY_ALGOLIA_SEARCH_KEY
@@ -69,7 +71,7 @@ const SearchModal = ({ onClose }) => {
         }
       `}
       render={({ site }) => {
-        const { docsSections } = site.siteMetadata
+        const { docsSections } = config
         return (
           <div className='fixed z-30 inset-0 min-h-screen'>
             <div className='flex items-end justify-center h-full pt-4 px-4 pb-20 text-center sm:block sm:p-0'>

--- a/src/components/search/SearchModal.js
+++ b/src/components/search/SearchModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react'
-import { navigate, StaticQuery, graphql } from 'gatsby'
+import { navigate } from 'gatsby'
 
 import {
   InstantSearch,
@@ -54,65 +54,45 @@ const SearchModal = ({ onClose }) => {
     onClose()
   }
 
+  const { docsSections } = config
+
   return (
-    <StaticQuery
-      query={graphql`
-        query {
-          site {
-            siteMetadata {
-              docsSections {
-                title
-                path
-                description
-                colorClass
-              }
-            }
-          }
-        }
-      `}
-      render={({ site }) => {
-        const { docsSections } = config
-        return (
-          <div className='fixed z-30 inset-0 min-h-screen'>
-            <div className='flex items-end justify-center h-full pt-4 px-4 pb-20 text-center sm:block sm:p-0'>
-              <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-                <div className="absolute inset-0 p-8" onClick={onClose} style={{
-                  background: 'rgba(0, 0, 0, 0.25)'
-                }}></div>
-              </div>
-              <div
-                className='shadow-xl transform transition-all inline-block bg-white rounded-lg text-left flex flex-col p-5 mx-auto max-w-xl my-8'
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="modal-headline"
-                style={{
-                  maxHeight: 'calc(100vh - 64px)'
-                }}
-              >
-                <InstantSearch
-                  indexName="Docs"
-                  searchClient={searchClient}
-                >
-                  <Configure hitsPerPage={5} />
-                  <div className='flex items-center'>
-                    <Icon icon='search' className='mr-3' size='sm'/>
-                    <div className='flex-grow'>
-                      <CustomSearchBox/>
-                    </div>
-                  </div>
-                  <div className='flex-shrink flex min-h-0'>
-                    <CustomResults>
-                      <CustomHits docsSections={docsSections} onClickHit={handleClickHit} />
-                    </CustomResults>
-                  </div>
-                </InstantSearch>
+    <div className='fixed z-30 inset-0 min-h-screen'>
+      <div className='flex items-end justify-center h-full pt-4 px-4 pb-20 text-center sm:block sm:p-0'>
+        <div className="fixed inset-0 transition-opacity" aria-hidden="true">
+          <div className="absolute inset-0 p-8" onClick={onClose} style={{
+            background: 'rgba(0, 0, 0, 0.25)'
+          }}></div>
+        </div>
+        <div
+          className='shadow-xl transform transition-all inline-block bg-white rounded-lg text-left flex flex-col p-5 mx-auto max-w-xl my-8'
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-headline"
+          style={{
+            maxHeight: 'calc(100vh - 64px)'
+          }}
+        >
+          <InstantSearch
+            indexName="Docs"
+            searchClient={searchClient}
+          >
+            <Configure hitsPerPage={5} />
+            <div className='flex items-center'>
+              <Icon icon='search' className='mr-3' size='sm'/>
+              <div className='flex-grow'>
+                <CustomSearchBox/>
               </div>
             </div>
-          </div>
-        )
-      }}
-    />
-
+            <div className='flex-shrink flex min-h-0'>
+              <CustomResults>
+                <CustomHits docsSections={docsSections} onClickHit={handleClickHit} />
+              </CustomResults>
+            </div>
+          </InstantSearch>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,15 +7,6 @@ import VideoContainer from '../components/VideoContainer'
 import SearchInput from '../components/SearchInput'
 import DatasetCard from '../components/DatasetCard'
 
-// the first argument in track() becomes the google analytics 'Action' property after passing through segment
-// all events are of Action 'Homepage'
-const fireEvent = (category, label) => {
-  window.analytics.track('Homepage', {
-    category,
-    label
-  })
-}
-
 const IndexPage = () => {
   const features = [
     {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const { fontFamily } = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  purge: [],
+  purge: ['./src/**/*.{js,jsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {


### PR DESCRIPTION
Cleans up several build warnings
- adds purging of unused tailwind css
- cleans up unused imports, etc that eslint was yelling about
- removes unused graphql queries for siteMetadata (no longer needed as `docsSections` is imported from config outside of graphql)