### PR TITLE
Various fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,7 +64,6 @@ const plugins = [
         {
           resolve: 'gatsby-remark-autolink-headers',
           options: {
-            offsetY: '200',
             icon: false
           }
         }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -186,3 +186,21 @@ body {
 .hide-scrollbars::-webkit-scrollbar {
   display: none;
 }
+
+// gatsby-remark-autolink-headers should have an offsetY option to accomplish this,
+// but we couldn't get it working.  This will make sure that when jumping to an anchor, it appears below the header
+:target::before {
+  content: "";
+  display: block;
+  height: 85px; /* fixed header height*/
+  margin: -85px 0 0; /* negative fixed header height */
+}
+
+@media only screen and (max-width:40em) {
+  :target::before {
+    content: "";
+    display: block;
+    height: 170px; /* fixed header height*/
+    margin: -170px 0 0; /* negative fixed header height */
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,13 @@
 const { fontFamily } = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  purge: ['./src/**/*.{js,jsx}'],
+  purge: {
+    content: ['./src/**/*.{js,jsx}'],
+    options: {
+      // these are used in config but not defined in the jsx
+      safelist: ['text-qrigreen-600', 'text-qrinavy-300']
+    }
+  },
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {


### PR DESCRIPTION
- Adds two colors to tailwind purge `safeList` (they were only used in js code config objects, not in JSX, so were not available in the built site)
(Closes #293)

- Manually offset `target` elements so that right sidebar (contents) links will scroll to the correct spot on the page (Closes #275)