### PR TITLE
fix: clarify hierarchy in starlark docs right sidebar

### DIFF
--- a/content/docs/reference/starlark-packages/bsoup.md
+++ b/content/docs/reference/starlark-packages/bsoup.md
@@ -28,7 +28,7 @@ parseHtml parses html from a string, returning the root SoupNode
 
 **Methods**
 
-### find
+#### find
 
 ```
 find(name, attrs, recursive, string, **kwargs)
@@ -38,7 +38,7 @@ retrieve the first occurrence of an element that matches arguments passed to fin
 works similarly to [node.find()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find)
 
 
-### find_all
+#### find_all
 
 ```
 find_all(name, attrs, recursive, string, limit, **kwargs)
@@ -48,7 +48,7 @@ retrieves all descendants that match arguments passed to find_all.
 works similarly to [node.find_all()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all)
 
 
-### attrs
+#### attrs
 
 ```
 attrs()
@@ -58,7 +58,7 @@ get a dictionary of element attributes
 works similarly to [node.attrs](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#attributes)
 
 
-### contents
+#### contents
 
 ```
 contents()
@@ -68,7 +68,7 @@ gets the list of children of an element
 works similarly to [soup.contents](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#contents-and-children)
 
 
-### child
+#### child
 
 ```
 child()
@@ -78,7 +78,7 @@ gets a single child element with the given tag name
 works like accessing a node [using its tag name](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#navigating-using-tag-names)
 
 
-### parent
+#### parent
 
 ```
 parent()
@@ -88,7 +88,7 @@ gets the parent node of an element
 works like [node.parent](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#parent)
 
 
-### next_sibling
+#### next_sibling
 
 ```
 next_sibling()
@@ -98,7 +98,7 @@ gets the next sibling of an element
 works like [node.next_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
 
 
-### prev_sibling
+#### prev_sibling
 
 ```
 prev_sibling()
@@ -108,7 +108,7 @@ gets the previous sibling of an element
 works like [node.prev_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
 
 
-### get_text
+#### get_text
 
 ```
 get_text()

--- a/content/docs/reference/starlark-packages/dataframe.md
+++ b/content/docs/reference/starlark-packages/dataframe.md
@@ -115,7 +115,7 @@ a dataframe
 
 **Methods**
 
-### append
+#### append
 
 ```
 append(other) DataFrame
@@ -123,7 +123,7 @@ append(other) DataFrame
 
 appends data to the rows of this DataFrame, returned as a new DataFrame
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -131,7 +131,7 @@ appends data to the rows of this DataFrame, returned as a new DataFrame
 
 
 
-### apply
+#### apply
 
 ```
 apply(function, axis) Series
@@ -139,7 +139,7 @@ apply(function, axis) Series
 
 travel the given axis and apply the function to each slice. The result values of that function are collected into a Series, which is returned
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -148,7 +148,7 @@ travel the given axis and apply the function to each slice. The result values of
 
 
 
-### drop
+#### drop
 
 ```
 drop(labels, axis, index, columns)
@@ -156,7 +156,7 @@ drop(labels, axis, index, columns)
 
 drop columns or rows from the DataFrame
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -167,7 +167,7 @@ drop columns or rows from the DataFrame
 
 
 
-### drop_duplicates
+#### drop_duplicates
 
 ```
 drop_duplicates(subset)
@@ -175,7 +175,7 @@ drop_duplicates(subset)
 
 drop duplicate rows of the DataFrame
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -183,7 +183,7 @@ drop duplicate rows of the DataFrame
 
 
 
-### groupby
+#### groupby
 
 ```
 groupby(by) GroupByResult
@@ -191,13 +191,13 @@ groupby(by) GroupByResult
 
 group a set of row according to some given column value
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
 | `by` | `list(string)` | a list of column names to use for grouping the rows together |
 
-#### examples:
+##### examples:
 **groupby**
 
 group rows according to the values in the given column
@@ -216,7 +216,7 @@ num_breeds = df.groupby(['species'])['breed'].count()
 
 
 
-### head
+#### head
 
 ```
 head(n?) DataFrame
@@ -224,7 +224,7 @@ head(n?) DataFrame
 
 return the first n row of the DataFrame
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -232,7 +232,7 @@ return the first n row of the DataFrame
 
 
 
-### merge
+#### merge
 
 ```
 merge(right, left_on, right_on, how, suffixes) DataFrame
@@ -240,7 +240,7 @@ merge(right, left_on, right_on, how, suffixes) DataFrame
 
 merge this with the right DataFrame, returned as a new DataFrame
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -252,13 +252,46 @@ merge this with the right DataFrame, returned as a new DataFrame
 
 
 
-### reset_index
+#### reset_index
 
 ```
 reset_index()
 ```
 
 resets the index to be an empty index, turning the previous index into its own column
+
+
+#### sort_values
+
+```
+sort_values(by, ascending?) DataFrame
+```
+
+sort the values in the DataFrame
+
+##### parameters:
+
+| name | type | description |
+|------|------|-------------|
+| `by` | `list(string)` | the columns to use to sort the values |
+| `ascending` | `bool` | whether to use ascending order, default is True |
+
+##### examples:
+**sort_values**
+
+sort the values
+
+```
+load("dataframe.star", "dataframe")
+df = dataframe.DataFrame(columns=['id','animal','sound'],
+data=[[1,'cat','meow'],
+[2,'dog','bark'],
+[3,'eel','zap'],
+[4,'frog','ribbit']])
+sorted = df.sort_values(by=['sound'])
+```
+
+
 
 ### Index
 
@@ -276,7 +309,7 @@ a series of values of one type, which represents a column of a DataFrame
 
 **Methods**
 
-### astype
+#### astype
 
 ```
 astype(type) Series
@@ -284,7 +317,7 @@ astype(type) Series
 
 coerce the values in the Series to the given type
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -292,7 +325,7 @@ coerce the values in the Series to the given type
 
 
 
-### equals
+#### equals
 
 ```
 equals(value) Series
@@ -300,7 +333,7 @@ equals(value) Series
 
 return a Series of bools for whether each element is equal to the value
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -308,7 +341,7 @@ return a Series of bools for whether each element is equal to the value
 
 
 
-### get
+#### get
 
 ```
 get(index) any
@@ -316,7 +349,7 @@ get(index) any
 
 gets the cell at the given index
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -324,7 +357,7 @@ gets the cell at the given index
 
 
 
-### notequals
+#### notequals
 
 ```
 notequals(value) Series
@@ -332,7 +365,7 @@ notequals(value) Series
 
 return a Series of bools for whether each element is not equal to the parameter
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -340,7 +373,7 @@ return a Series of bools for whether each element is not equal to the parameter
 
 
 
-### notnull
+#### notnull
 
 ```
 notnull() Series
@@ -349,7 +382,7 @@ notnull() Series
 return a Series of bools for whether each element is not null
 
 
-### unique
+#### unique
 
 ```
 unique() Series
@@ -363,7 +396,7 @@ string functions that will be applied to all strings in the collection
 
 **Methods**
 
-### contains
+#### contains
 
 ```
 contains(text)
@@ -371,7 +404,7 @@ contains(text)
 
 whether each string contains the given text
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -379,7 +412,7 @@ whether each string contains the given text
 
 
 
-### endswith
+#### endswith
 
 ```
 endswith(text)
@@ -387,7 +420,7 @@ endswith(text)
 
 whether each string ends with the given text
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -395,7 +428,7 @@ whether each string ends with the given text
 
 
 
-### lower
+#### lower
 
 ```
 lower()
@@ -404,7 +437,7 @@ lower()
 convert the strings to lower case
 
 
-### replace
+#### replace
 
 ```
 replace(needle, new)
@@ -412,7 +445,7 @@ replace(needle, new)
 
 replace the needle in each string with the new text
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -421,7 +454,7 @@ replace the needle in each string with the new text
 
 
 
-### startswith
+#### startswith
 
 ```
 startswith(text)
@@ -429,7 +462,7 @@ startswith(text)
 
 whether each string starts with the given text
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -437,7 +470,7 @@ whether each string starts with the given text
 
 
 
-### strip
+#### strip
 
 ```
 strip()

--- a/content/docs/reference/starlark-packages/geo.md
+++ b/content/docs/reference/starlark-packages/geo.md
@@ -178,7 +178,7 @@ a two-dimensional point in space
 
 **Methods**
 
-### distance
+#### distance
 
 ```
 distance(p2) float
@@ -186,7 +186,7 @@ distance(p2) float
 
 Euclidean Distance to the other point
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -194,7 +194,7 @@ Euclidean Distance to the other point
 
 
 
-### distanceGeodesic
+#### distanceGeodesic
 
 ```
 distanceGeodesic(p2) float
@@ -202,7 +202,7 @@ distanceGeodesic(p2) float
 
 Distance on the surface of a sphere with the same radius as Earth
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -215,7 +215,7 @@ an ordered list of points that define a line
 
 **Methods**
 
-### length
+#### length
 
 ```
 length() float
@@ -224,7 +224,7 @@ length() float
 Euclidean Length
 
 
-### lengthGeodesic
+#### lengthGeodesic
 
 ```
 lengthGeodesic() float

--- a/content/docs/reference/starlark-packages/html.md
+++ b/content/docs/reference/starlark-packages/html.md
@@ -35,7 +35,7 @@ an HTML document for querying
 
 **Methods**
 
-### attr
+#### attr
 
 ```
 attr(name) string
@@ -44,7 +44,7 @@ attr(name) string
 gets the specified attribute's value for the first element in the Selection.
 To get the value for each element individually, use a looping construct such as each or map method
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -52,7 +52,7 @@ To get the value for each element individually, use a looping construct such as 
 
 
 
-### children
+#### children
 
 ```
 children() selection
@@ -61,7 +61,7 @@ children() selection
 gets the child elements of each element in the Selection
 
 
-### children_filtered
+#### children_filtered
 
 ```
 children_filtered(selector) selection
@@ -69,7 +69,7 @@ children_filtered(selector) selection
 
 gets the child elements of each element in the Selection, filtered by the specified selector
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -77,7 +77,7 @@ gets the child elements of each element in the Selection, filtered by the specif
 
 
 
-### contents
+#### contents
 
 ```
 contents(selector) selection
@@ -85,7 +85,7 @@ contents(selector) selection
 
 gets the children of each element in the Selection, including text and comment nodes
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -93,7 +93,7 @@ gets the children of each element in the Selection, including text and comment n
 
 
 
-### find
+#### find
 
 ```
 find(selector) selection
@@ -101,7 +101,7 @@ find(selector) selection
 
 gets the descendants of each element in the current set of matched elements, filtered by a selector
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -109,7 +109,7 @@ gets the descendants of each element in the current set of matched elements, fil
 
 
 
-### filter
+#### filter
 
 ```
 filter(selector) selection
@@ -117,7 +117,7 @@ filter(selector) selection
 
 filter reduces the set of matched elements to those that match the selector string
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -125,7 +125,7 @@ filter reduces the set of matched elements to those that match the selector stri
 
 
 
-### get
+#### get
 
 ```
 get(i) selection
@@ -133,7 +133,7 @@ get(i) selection
 
 retrieves the underlying node at the specified index. alias: eq
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -141,7 +141,7 @@ retrieves the underlying node at the specified index. alias: eq
 
 
 
-### has
+#### has
 
 ```
 has(selector) selection
@@ -149,7 +149,7 @@ has(selector) selection
 
 reduces the set of matched elements to those that have a descendant that matches the selector
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -157,7 +157,7 @@ reduces the set of matched elements to those that have a descendant that matches
 
 
 
-### isSelector
+#### isSelector
 
 ```
 isSelector(selector) bool
@@ -165,7 +165,7 @@ isSelector(selector) bool
 
 checks the current matched set of elements against a selector and returns true if at least one of these elements matches
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -173,7 +173,7 @@ checks the current matched set of elements against a selector and returns true i
 
 
 
-### parent
+#### parent
 
 ```
 parent(selector) selection
@@ -181,7 +181,7 @@ parent(selector) selection
 
 gets the parent of each element in the Selection
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -189,7 +189,7 @@ gets the parent of each element in the Selection
 
 
 
-### parents_until
+#### parents_until
 
 ```
 parents_until(selector) selection
@@ -197,7 +197,7 @@ parents_until(selector) selection
 
 gets the ancestors of each element in the Selection, up to but not including the element matched by the selector
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -205,7 +205,7 @@ gets the ancestors of each element in the Selection, up to but not including the
 
 
 
-### siblings
+#### siblings
 
 ```
 siblings() selection
@@ -214,7 +214,7 @@ siblings() selection
 gets the siblings of each element in the Selection
 
 
-### text
+#### text
 
 ```
 text() string
@@ -223,7 +223,7 @@ text() string
 gets the combined text contents of each element in the set of matched elements, including descendants
 
 
-### first
+#### first
 
 ```
 first(selector) selection
@@ -231,7 +231,7 @@ first(selector) selection
 
 gets the first element of the selection
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -239,7 +239,7 @@ gets the first element of the selection
 
 
 
-### last
+#### last
 
 ```
 last() selection
@@ -247,7 +247,7 @@ last() selection
 
 gets the last element of the selection
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
@@ -255,7 +255,7 @@ gets the last element of the selection
 
 
 
-### len
+#### len
 
 ```
 len() int
@@ -264,7 +264,7 @@ len() int
 returns the number of the nodes in the selection
 
 
-### eq
+#### eq
 
 ```
 eq(i) selection
@@ -272,7 +272,7 @@ eq(i) selection
 
 gets the element at index i of the selection
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|

--- a/content/docs/reference/starlark-packages/http.md
+++ b/content/docs/reference/starlark-packages/http.md
@@ -157,7 +157,7 @@ the result of performing a http request
 
 **Methods**
 
-### body
+#### body
 
 ```
 body() string
@@ -166,7 +166,7 @@ body() string
 output response body as a string
 
 
-### json
+#### json
 
 ```
 json()

--- a/content/docs/reference/starlark-packages/re.md
+++ b/content/docs/reference/starlark-packages/re.md
@@ -121,28 +121,28 @@ return a corresponding match string tuple. Return None if the string does not ma
 
 **Methods**
 
-### match
+#### match
 
 ```
 match(text, flags=0)
 ```
 
 
-### findall
+#### findall
 
 ```
 findall(text, flags=0)
 ```
 
 
-### split
+#### split
 
 ```
 split(text, maxsplit=0, flags=0)
 ```
 
 
-### sub
+#### sub
 
 ```
 sub(repl, text, count=0, flags=0)

--- a/content/docs/reference/starlark-packages/time.md
+++ b/content/docs/reference/starlark-packages/time.md
@@ -117,7 +117,7 @@ methods.
 
 **Methods**
 
-### in_location
+#### in_location
 
 ```
 in_location(locstr) Time
@@ -126,7 +126,7 @@ in_location(locstr) Time
 get time representing the same instant but in a different location
 
 
-### format
+#### format
 
 ```
 format() string
@@ -135,7 +135,7 @@ format() string
 textual representation of time formatted according to the provided
 layout string: 01/02 03:04:05PM '06 -0700 (January 2, 15:04:05, 2006,
 in time zone seven hours west of GMT)
-#### examples:
+##### examples:
 **ISO timestamp**
 
 construct an ISO tiemstamp using the template string

--- a/content/docs/reference/starlark-packages/xlsx.md
+++ b/content/docs/reference/starlark-packages/xlsx.md
@@ -28,7 +28,7 @@ an excel file
 
 **Methods**
 
-### get_sheets
+#### get_sheets
 
 ```
 get_sheets() dict
@@ -37,7 +37,7 @@ get_sheets() dict
 return a dict of sheets in this excel file
 
 
-### get_rows
+#### get_rows
 
 ```
 get_rows(sheetname) list

--- a/content/docs/reference/starlark-packages/zipfile.md
+++ b/content/docs/reference/starlark-packages/zipfile.md
@@ -49,14 +49,14 @@ a zip archive object
 
 **Methods**
 
-### namelist
+#### namelist
 
 ```
 namelist() list
 ```
 
 return a list of files in the archive
-#### examples:
+##### examples:
 **basic**
 
 get list of filenames from ZipFile
@@ -71,7 +71,7 @@ print(files) # ["file1.txt", "file2.txt", etc ]
 
 
 
-### open
+#### open
 
 ```
 open(filename string) ZipInfo
@@ -79,13 +79,13 @@ open(filename string) ZipInfo
 
 open a file for reading
 
-#### parameters:
+##### parameters:
 
 | name | type | description |
 |------|------|-------------|
 | `filename` | `string` | name of the file in the archive to open |
 
-#### examples:
+##### examples:
 **basic**
 
 open file from ZipArchive as a ZipInfo
@@ -106,14 +106,14 @@ an information object for interacting with a Zip archive component
 
 **Methods**
 
-### read
+#### read
 
 ```
 read() string
 ```
 
 read the file, returning it's string representation
-#### examples:
+##### examples:
 **basic**
 
 read file

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -34,11 +34,24 @@ const RightSidebar = ({ location }) => (
                         {title}
                       </a>
                       <ul>
-                        {items && items.map(({ url, title, items }) => (
+                        {items && items.map(({ url, title: secondTierTitle, items }) => (
                           <li className='text-qrigray-400 hover:text-qripink transition-all duration-200 mb-2 ml-2 mt-1' key={title}>
                             <a href={url}>
-                              {title}
+                              {secondTierTitle}
                             </a>
+                            {/* Only show third tier if title is 'Types' */}
+                            {title === 'Types' && (
+                              <ul>
+                                {items && items.map(({ url, title: thirdTierTitle, items }) => (
+                                  <li className='text-qrigray-400 hover:text-qripink transition-all duration-200 mb-2 ml-2 mt-1 text-xs' key={title}>
+                                    <a href={url}>
+                                      {thirdTierTitle}
+                                    </a>
+                                  </li>
+                                ))
+                                }
+                              </ul>
+                            )}
                           </li>
                         ))
                         }


### PR DESCRIPTION
Depends on changes in https://github.com/qri-io/starlib/pull/151
Closes #341 

Along with a change to the docs template file in starlib, this changes the heading tags in starlark docs so that the correct hierarchy can be shown in starlark package docs tables of contents:

![dataframe___Qri_io](https://user-images.githubusercontent.com/1833820/143131767-c64218d2-fca5-4f26-8ccd-10bfddad0ea1.png)

Note: We only show "third tier" items under the `Types` top-level heading.  This is hard coded and can be changed if we need to expand it to other sections. (If left to always show, we end up seeing "parameters" as a third-tier item under top-level functions, which is not something we want.
